### PR TITLE
Change the Swift Language Version to 4.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,5 +18,5 @@ let package = Package(
             name: "GPUImage",
             path: "framework/Source",
             exclude: ["Linux", "Operations/Shaders"])],
-    swiftLanguageVersions: [.v4]
+    swiftLanguageVersions: [.v4_2]
 )

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ BSD-style, with the full license available with the framework in License.txt.
 
 ## Technical requirements ##
 
-- Swift 4
-- Xcode 9.0 on Mac or iOS
+- Swift 4.2
+- Xcode 10.2 or higher on Mac or iOS
 - iOS: 9.0 or higher
 - OSX: 10.11 or higher
 


### PR DESCRIPTION
GPUImage uses names from the Swift 4.2 API (and thus does not compile with the current .v4 setting in Package.swift).

This pull request makes GPUImage compile again under Xcode 11, by changing the Swift language version to 4.2, and updates the README accordingly.