### PR TITLE
Fix incorrect buffer size and offsets by using MTLAutoreleasedRenderPipelineReflection

### DIFF
--- a/framework/Source/BasicOperation.swift
+++ b/framework/Source/BasicOperation.swift
@@ -41,9 +41,9 @@ open class BasicOperation: ImageProcessingOperation {
         self.operationName = operationName
         
         let concreteVertexFunctionName = vertexFunctionName ?? defaultVertexFunctionNameForInputs(numberOfInputs)
-        let (pipelineState, lookupTable) = generateRenderPipelineState(device:sharedMetalRenderingDevice, vertexFunctionName:concreteVertexFunctionName, fragmentFunctionName:fragmentFunctionName, operationName:operationName)
+        let (pipelineState, lookupTable, bufferSize) = generateRenderPipelineState(device:sharedMetalRenderingDevice, vertexFunctionName:concreteVertexFunctionName, fragmentFunctionName:fragmentFunctionName, operationName:operationName)
         self.renderPipelineState = pipelineState
-        self.uniformSettings = ShaderUniformSettings(uniformLookupTable:lookupTable)
+        self.uniformSettings = ShaderUniformSettings(uniformLookupTable:lookupTable, bufferSize:bufferSize)
     }
     
     public func transmitPreviousImage(to target: ImageConsumer, atIndex: UInt) {

--- a/framework/Source/Camera.swift
+++ b/framework/Source/Camera.swift
@@ -68,7 +68,8 @@ public class Camera: NSObject, ImageSource, AVCaptureVideoDataOutputSampleBuffer
     var supportsFullYUVRange:Bool = false
     let captureAsYUV:Bool
     let yuvConversionRenderPipelineState:MTLRenderPipelineState?
-    var yuvLookupTable:[String:(Int, MTLDataType)] = [:]
+    var yuvLookupTable:[String:(Int, MTLStructMember)] = [:]
+    var yuvBufferSize:Int = 0
     
     let frameRenderingSemaphore = DispatchSemaphore(value:1)
     let cameraProcessingQueue = DispatchQueue.global()
@@ -133,15 +134,17 @@ public class Camera: NSObject, ImageSource, AVCaptureVideoDataOutputSampleBuffer
                 }
             }
             if (supportsFullYUVRange) {
-                let (pipelineState, lookupTable) = generateRenderPipelineState(device:sharedMetalRenderingDevice, vertexFunctionName:"twoInputVertex", fragmentFunctionName:"yuvConversionFullRangeFragment", operationName:"YUVToRGB")
+                let (pipelineState, lookupTable, bufferSize) = generateRenderPipelineState(device:sharedMetalRenderingDevice, vertexFunctionName:"twoInputVertex", fragmentFunctionName:"yuvConversionFullRangeFragment", operationName:"YUVToRGB")
                 self.yuvConversionRenderPipelineState = pipelineState
                 self.yuvLookupTable = lookupTable
+                self.yuvBufferSize = bufferSize
                 videoOutput.videoSettings = [kCVPixelBufferMetalCompatibilityKey as String: true,
                                              kCVPixelBufferPixelFormatTypeKey as String:NSNumber(value:Int32(kCVPixelFormatType_420YpCbCr8BiPlanarFullRange))]
             } else {
-                let (pipelineState, lookupTable) = generateRenderPipelineState(device:sharedMetalRenderingDevice, vertexFunctionName:"twoInputVertex", fragmentFunctionName:"yuvConversionVideoRangeFragment", operationName:"YUVToRGB")
+                let (pipelineState, lookupTable, bufferSize) = generateRenderPipelineState(device:sharedMetalRenderingDevice, vertexFunctionName:"twoInputVertex", fragmentFunctionName:"yuvConversionVideoRangeFragment", operationName:"YUVToRGB")
                 self.yuvConversionRenderPipelineState = pipelineState
                 self.yuvLookupTable = lookupTable
+                self.yuvBufferSize = bufferSize
                 videoOutput.videoSettings = [kCVPixelBufferMetalCompatibilityKey as String: true,
                                              kCVPixelBufferPixelFormatTypeKey as String:NSNumber(value:Int32(kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange))]
             }
@@ -219,7 +222,7 @@ public class Camera: NSObject, ImageSource, AVCaptureVideoDataOutputSampleBuffer
                     }
                     let outputTexture = Texture(device:sharedMetalRenderingDevice.device, orientation:.portrait, width:outputWidth, height:outputHeight, timingStyle: .videoFrame(timestamp: Timestamp(currentTime)))
                     
-                    convertYUVToRGB(pipelineState:self.yuvConversionRenderPipelineState!, lookupTable:self.yuvLookupTable,
+                    convertYUVToRGB(pipelineState:self.yuvConversionRenderPipelineState!, lookupTable:self.yuvLookupTable, bufferSize:self.yuvBufferSize,
                                     luminanceTexture:Texture(orientation: self.orientation ?? self.location.imageOrientation(), texture:luminanceTexture),
                                     chrominanceTexture:Texture(orientation: self.orientation ?? self.location.imageOrientation(), texture:chrominanceTexture),
                                     resultTexture:outputTexture, colorConversionMatrix:conversionMatrix)

--- a/framework/Source/MetalRenderingDevice.swift
+++ b/framework/Source/MetalRenderingDevice.swift
@@ -14,12 +14,12 @@ public class MetalRenderingDevice {
     public let metalPerformanceShadersAreSupported: Bool
     
     lazy var passthroughRenderState: MTLRenderPipelineState = {
-        let (pipelineState, _) = generateRenderPipelineState(device:self, vertexFunctionName:"oneInputVertex", fragmentFunctionName:"passthroughFragment", operationName:"Passthrough")
+        let (pipelineState, _, _) = generateRenderPipelineState(device:self, vertexFunctionName:"oneInputVertex", fragmentFunctionName:"passthroughFragment", operationName:"Passthrough")
         return pipelineState
     }()
 
     lazy var colorSwizzleRenderState: MTLRenderPipelineState = {
-        let (pipelineState, _) = generateRenderPipelineState(device:self, vertexFunctionName:"oneInputVertex", fragmentFunctionName:"colorSwizzleFragment", operationName:"ColorSwizzle")
+        let (pipelineState, _, _) = generateRenderPipelineState(device:self, vertexFunctionName:"oneInputVertex", fragmentFunctionName:"colorSwizzleFragment", operationName:"ColorSwizzle")
         return pipelineState
     }()
 

--- a/framework/Source/MovieOutput.swift
+++ b/framework/Source/MovieOutput.swift
@@ -63,7 +63,7 @@ public class MovieOutput: ImageConsumer, AudioEncodingTarget {
         assetWriterPixelBufferInput = AVAssetWriterInputPixelBufferAdaptor(assetWriterInput:assetWriterVideoInput, sourcePixelBufferAttributes:sourcePixelBufferAttributesDictionary)
         assetWriter.add(assetWriterVideoInput)
         
-        let (pipelineState, _) = generateRenderPipelineState(device:sharedMetalRenderingDevice, vertexFunctionName:"oneInputVertex", fragmentFunctionName:"passthroughFragment", operationName:"RenderView")
+        let (pipelineState, _, _) = generateRenderPipelineState(device:sharedMetalRenderingDevice, vertexFunctionName:"oneInputVertex", fragmentFunctionName:"passthroughFragment", operationName:"RenderView")
         self.renderPipelineState = pipelineState
     }
     

--- a/framework/Source/RenderView.swift
+++ b/framework/Source/RenderView.swift
@@ -26,7 +26,7 @@ public class RenderView: MTKView, ImageConsumer {
         
         self.device = sharedMetalRenderingDevice.device
         
-        let (pipelineState, _) = generateRenderPipelineState(device:sharedMetalRenderingDevice, vertexFunctionName:"oneInputVertex", fragmentFunctionName:"passthroughFragment", operationName:"RenderView")
+        let (pipelineState, _, _) = generateRenderPipelineState(device:sharedMetalRenderingDevice, vertexFunctionName:"oneInputVertex", fragmentFunctionName:"passthroughFragment", operationName:"RenderView")
         self.renderPipelineState = pipelineState
         
         enableSetNeedsDisplay = false

--- a/framework/Source/ShaderUniformSettings.swift
+++ b/framework/Source/ShaderUniformSettings.swift
@@ -10,10 +10,10 @@ public class ShaderUniformSettings {
         label: "com.sunsetlakesoftware.GPUImage.shaderUniformSettings",
         attributes: [])
 
-    public init(uniformLookupTable:[String:(Int, MTLStructMember)], bufferSize: Int) {
+    public init(uniformLookupTable:[String:(Int, MTLStructMember)], bufferSize:Int) {
         var convertedLookupTable:[String:Int] = [:]
         
-        var orderedOffsets = [Int](repeating: 0, count: uniformLookupTable.count)
+        var orderedOffsets = [Int](repeating:0, count:uniformLookupTable.count)
         
         for (key, uniform) in uniformLookupTable {
             let (index, structMember) = uniform

--- a/framework/Source/YUVToRGBConversion.swift
+++ b/framework/Source/YUVToRGBConversion.swift
@@ -21,7 +21,7 @@ public let colorConversionMatrix709Default = Matrix3x3(rowMajorValues:[
     1.793, -0.533,   0.0,
 ])
 
-public func convertYUVToRGB(pipelineState:MTLRenderPipelineState, lookupTable:[String:(Int, MTLStructMember)], bufferSize: Int, luminanceTexture:Texture, chrominanceTexture:Texture, secondChrominanceTexture:Texture? = nil, resultTexture:Texture, colorConversionMatrix:Matrix3x3) {
+public func convertYUVToRGB(pipelineState:MTLRenderPipelineState, lookupTable:[String:(Int, MTLStructMember)], bufferSize:Int, luminanceTexture:Texture, chrominanceTexture:Texture, secondChrominanceTexture:Texture? = nil, resultTexture:Texture, colorConversionMatrix:Matrix3x3) {
     let uniformSettings = ShaderUniformSettings(uniformLookupTable:lookupTable, bufferSize:bufferSize)
     uniformSettings["colorConversionMatrix"] = colorConversionMatrix
     

--- a/framework/Source/YUVToRGBConversion.swift
+++ b/framework/Source/YUVToRGBConversion.swift
@@ -21,8 +21,8 @@ public let colorConversionMatrix709Default = Matrix3x3(rowMajorValues:[
     1.793, -0.533,   0.0,
 ])
 
-public func convertYUVToRGB(pipelineState:MTLRenderPipelineState, lookupTable:[String:(Int, MTLDataType)], luminanceTexture:Texture, chrominanceTexture:Texture, secondChrominanceTexture:Texture? = nil, resultTexture:Texture, colorConversionMatrix:Matrix3x3) {
-    let uniformSettings = ShaderUniformSettings(uniformLookupTable:lookupTable)
+public func convertYUVToRGB(pipelineState:MTLRenderPipelineState, lookupTable:[String:(Int, MTLStructMember)], bufferSize: Int, luminanceTexture:Texture, chrominanceTexture:Texture, secondChrominanceTexture:Texture? = nil, resultTexture:Texture, colorConversionMatrix:Matrix3x3) {
+    let uniformSettings = ShaderUniformSettings(uniformLookupTable:lookupTable, bufferSize:bufferSize)
     uniformSettings["colorConversionMatrix"] = colorConversionMatrix
     
     guard let commandBuffer = sharedMetalRenderingDevice.commandQueue.makeCommandBuffer() else {return}


### PR DESCRIPTION
Use [buffer size](https://developer.apple.com/documentation/metal/mtlargument/1461986-bufferdatasize) and [offsets](https://developer.apple.com/documentation/metal/mtlstructmember/1461970-offset) directly from MTLAutoreleasedRenderPipelineReflection instead of manually calculating