### PR TITLE
fix vignette operation crash issue

### DIFF
--- a/framework/Source/Operations/BulgeDistortion.swift
+++ b/framework/Source/Operations/BulgeDistortion.swift
@@ -9,5 +9,7 @@ public class BulgeDistortion: BasicOperation {
         ({radius = 0.25})()
         ({scale = 0.5})()
         ({center = Position.center})()
+        
+        uniformSettings.setUniformStride(byCountOfFloats: 6)
     }
 }

--- a/framework/Source/Operations/GlassSphere.swift
+++ b/framework/Source/Operations/GlassSphere.swift
@@ -10,6 +10,7 @@ public class GlassSphereRefraction: BasicOperation {
         ({refractiveIndex = 0.71})()
         ({center = Position.center})()
         
+        uniformSettings.setUniformStride(byCountOfFloats: 6)
 //        self.backgroundColor = Color(red:0.0, green:0.0, blue:0.0, alpha:0.0)
     }
 }

--- a/framework/Source/Operations/PinchDistortion.swift
+++ b/framework/Source/Operations/PinchDistortion.swift
@@ -9,5 +9,7 @@ public class PinchDistortion: BasicOperation {
         ({radius = 0.5})()
         ({scale = 0.5})()
         ({center = Position.center})()
+        
+        uniformSettings.setUniformStride(byCountOfFloats: 6)
     }
 }

--- a/framework/Source/Operations/SphereRefraction.swift
+++ b/framework/Source/Operations/SphereRefraction.swift
@@ -10,6 +10,7 @@ public class SphereRefraction: BasicOperation {
         ({refractiveIndex = 0.71})()
         ({center = Position.center})()
         
+        uniformSettings.setUniformStride(byCountOfFloats: 6)
 //        self.backgroundColor = Color(red:0.0, green:0.0, blue:0.0, alpha:0.0)
     }
 }

--- a/framework/Source/Operations/Vignette.swift
+++ b/framework/Source/Operations/Vignette.swift
@@ -11,5 +11,7 @@ public class Vignette: BasicOperation {
         ({color = Color.black})()
         ({start = 0.3})()
         ({end = 0.75})()
+        
+        uniformSettings.setUniformStride(byCountOfFloats: 12)
     }
 }

--- a/framework/Source/Operations/ZoomBlur.swift
+++ b/framework/Source/Operations/ZoomBlur.swift
@@ -7,5 +7,7 @@ public class ZoomBlur: BasicOperation {
         
         ({blurSize = 1.0})()
         ({blurCenter = Position.center})()
+        
+        uniformSettings.setUniformStride(byCountOfFloats: 4)
     }
 }

--- a/framework/Source/ShaderUniformSettings.swift
+++ b/framework/Source/ShaderUniformSettings.swift
@@ -64,6 +64,7 @@ public class ShaderUniformSettings {
                 let floatArray:[Float]
                 guard let index = self.uniformLookupTable[key] else {fatalError("Tried to access value of missing uniform: \(key), make sure this is present and used in your shader.")}
                 let startingIndex = self.internalIndex(for:index)
+
                 if self.colorUniformsUseAlpha {
                     floatArray = newValue.toFloatArrayWithAlpha()
                     self.uniformValues[startingIndex] = floatArray[0]
@@ -185,13 +186,25 @@ public class ShaderUniformSettings {
             return lastOffset
         }
     }
+    
+    func setUniformStride(byCountOfFloats count: Int) {
+        if uniformValues.count < count {
+            print("shader uniforms count less than stride: \(uniformValues.count) < \(count)")
+            uniformValues.append(contentsOf: [Float](repeating: 0.0, count:count - uniformValues.count))
+            
+        } else if uniformValues.count > count {
+            print("shader uniforms count greater than stride: \(uniformValues.count) > \(count)")
+        } else {
+            print("shader uniforms stride equals.")
+        }
+    }
 
     public func restoreShaderSettings(renderEncoder:MTLRenderCommandEncoder) {
         shaderUniformSettingsQueue.sync {
             guard (uniformValues.count > 0) else { return }
             
             let uniformBuffer = sharedMetalRenderingDevice.device.makeBuffer(bytes: uniformValues,
-                                                                             length: uniformValues.count * MemoryLayout<Float>.size,
+                                                                             length: uniformValues.count * MemoryLayout<Float>.stride,
                                                                              options: [])!
             renderEncoder.setFragmentBuffer(uniformBuffer, offset: 0, index: 1)
         }


### PR DESCRIPTION
Reason: Fragment Uniform buffer alignment issue. 
```
typedef struct {
    float2 vignetteCenter;
    float3 vignetteColor;
    float vignetteStart;
    float vignetteEnd;
} VignetteUniform;
```
this struct occupies 48 bytes, with the last 8 bytes useless.

the similar crash happens for zoom blur, bulge distortion, pinch distortion, sphere refraction, glass crash.