### PR TITLE
Fixed #63: fiexed crash when setting uniform argument buffer

### DIFF
--- a/framework/Source/BasicOperation.swift
+++ b/framework/Source/BasicOperation.swift
@@ -41,9 +41,7 @@ open class BasicOperation: ImageProcessingOperation {
         self.operationName = operationName
         
         let concreteVertexFunctionName = vertexFunctionName ?? defaultVertexFunctionNameForInputs(numberOfInputs)
-        let (pipelineState, lookupTable) = generateRenderPipelineState(device:sharedMetalRenderingDevice, vertexFunctionName:concreteVertexFunctionName, fragmentFunctionName:fragmentFunctionName, operationName:operationName)
-        self.renderPipelineState = pipelineState
-        self.uniformSettings = ShaderUniformSettings(uniformLookupTable:lookupTable)
+        (self.renderPipelineState, self.uniformSettings) = generateRenderPipelineState(device:sharedMetalRenderingDevice, vertexFunctionName:concreteVertexFunctionName, fragmentFunctionName:fragmentFunctionName, operationName:operationName)
     }
     
     public func transmitPreviousImage(to target: ImageConsumer, atIndex: UInt) {

--- a/framework/Source/YUVToRGBConversion.swift
+++ b/framework/Source/YUVToRGBConversion.swift
@@ -21,8 +21,7 @@ public let colorConversionMatrix709Default = Matrix3x3(rowMajorValues:[
     1.793, -0.533,   0.0,
 ])
 
-public func convertYUVToRGB(pipelineState:MTLRenderPipelineState, lookupTable:[String:(Int, MTLDataType)], luminanceTexture:Texture, chrominanceTexture:Texture, secondChrominanceTexture:Texture? = nil, resultTexture:Texture, colorConversionMatrix:Matrix3x3) {
-    let uniformSettings = ShaderUniformSettings(uniformLookupTable:lookupTable)
+public func convertYUVToRGB(pipelineState:MTLRenderPipelineState, uniformSettings:ShaderUniformSettings, luminanceTexture:Texture, chrominanceTexture:Texture, secondChrominanceTexture:Texture? = nil, resultTexture:Texture, colorConversionMatrix:Matrix3x3) {
     uniformSettings["colorConversionMatrix"] = colorConversionMatrix
     
     guard let commandBuffer = sharedMetalRenderingDevice.commandQueue.makeCommandBuffer() else {return}


### PR DESCRIPTION
Fixed #63:

- using MTLArgument to get right uniform argument buffer data size;
- `generateRenderPipelineState(device:vertexFunctionName:fragmentFunctionName:operationName:)` return ShaderUniformSettings directly;
- `convertYUVToRGB(pipelineState:uniformSettings:luminanceTexture:chrominanceTexture:secondChrominanceTexture:resultTexture:colorConversionMatrix:)` receive ShaderUniformSettings as uniformSettings parameter;